### PR TITLE
Aesthetic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Awesome list of tools you might need on your path to senior developer-dom
+
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 > A curated list of popular tools, tips and tricks for aspiring developers.
@@ -6,6 +7,7 @@
 > To add to the repo simply grab the name, link and a short searchable description of your favorites. Try to keep it to high level products you have personally tried and would recommend to your friends and coworkers. Also tools that you wish you knew about when you were starting as a junior developer are welcomed!
 
 # Index
+
 - [Tutorials](#tutorials)
 - [Articles](#articles)
 - [Blogs](#blogs)
@@ -19,6 +21,7 @@
 ___
 
 ## Tutorials
+
 - [Wes Bos Javascript 30](https://javascript30.com/) - Free vanilla JavaScript course covering the basics of JavaScript.
 - [Egghead.io](https://egghead.io/) - A Mix of free and paid courses for Front End Frameworks and JavaScript.
 - [Linkedin Learning](www.linkedin.com/learning) - A library of courses on a full range of a variety of topics. This was Lynda before.
@@ -33,6 +36,7 @@ ___
 ---
 
 ## Articles
+
 - [Design Patterns](https://sourcemaking.com/design_patterns) - Design Patterns explained in detail with examples.
 - [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well/) - How to become a programmer, or the art of Googling well.
 - [Software design pattern](https://en.wikipedia.org/wiki/Software_design_pattern) - The entire collection of Design Patterns.
@@ -53,6 +57,7 @@ ___
 ---
 
 ## Blogs
+
 - [The Practical Dev](https://dev.to/) - A collection of posts on life as a programmer, technical posts etc. 
 - [A List Apart: For People Who Make Websites](http://alistapart.com/) - One of the most popular and influential web design blogs.
 - [Web Designer Depot — Web Design Blog](http://www.webdesignerdepot.com/) - WebDesigner Depot provides great posts about web design. Definitely one of the biggest blogs about web design and an excellent resource to keep handy.
@@ -60,26 +65,31 @@ ___
 ---
 
 ## Books
+
 ### About the Mind
+
 - Thinking, Fast and Slow - Daniel Kahneman
 - The Organized Mind - Daniel J Levitin
 
 ### Computer Science
+
 - Computer Science Distilled - Wladston Ferriera 
 
 ### General
+
 - Refactoring - Martin Fowler
 - Zero Bugs and Program Faster - Kate Thompson
 - The Mythical Man Month - Fred Brooks
-- [Pragmatic Programmer] - Andy Hunt and Dave Thomas
+- Pragmatic Programmer - Andy Hunt and Dave Thomas
 - Extreme Programming Explained - Kent Beck
 - Introduction to Algorithms - Thomas H Cormen
 - Clean Code: A Handbook of Agile Software Craftsmanship - Robert C Martin
 - Cracking the Coding Interview - Gayle Laakmann
-- 2018 Front-End Developer Handbook(https://frontendmasters.com/books/front-end-handbook/2018/) - Cody Lindley
+- [2018 Front-End Developer Handbook](https://frontendmasters.com/books/front-end-handbook/2018/) - Cody Lindley
 - DevOps for Dummies - Emily Freeman
 
 ### JavaScript
+
 - JavaScript: The Good Parts - Douglas Crockford
 - Learning JavaScript Design Patterns - Addy Osmani
 - Programming JavaScript Applications - Eric Elliott
@@ -89,16 +99,19 @@ ___
 - [Eloquent JavaScript](http://eloquentjavascript.net/) - Marijn Haverbeke
 
 ### Object Oriented Design
+
 - Design Patterns: Elements of Reusable Object-Oriented Software- aka the "Gang Of Four" book, or GOF
 - Practical Object-Oriented Design in Ruby - Sandi Metz
 - Growing Object-Oriented Software Guided by Tests - Steve Freeman and Nat Pryce
 - Design Patterns Explained Simply - Alexander Shvets
 
 ### Python
+
 - [Digital Ocean- How to Code in Python](https://www.digitalocean.com/community/tutorials/digitalocean-ebook-how-to-code-in-python) - A free e-book created for beginners learning to code in Python.
 - Python All-in-One for Dummies- John Shovic
 
 ### UX/Design
+
 - Don't Make Me Think - Steve Krug
 - Lessons in Typography - Jim Krause
 - User Experience Revolution - Paul Boag
@@ -106,15 +119,16 @@ ___
 ---
 
 ## News
+
 - [Tech Crunch](https://techcrunch.com/)
 - [Hacker News](https://news.ycombinator.com/)
 - [Wired](https://www.wired.com/)
 - [Reddit WebDev](https://www.reddit.com/r/webdev/)
 
-
 ---
 
 ## Newsletters
+
 - [JavaScript Weekly](http://javascriptweekly.com/) - Weekly newsletter with only JS News
 - [The UI Animation Newsletter](http://valhead.com/newsletter/) - Newsletter covering topics on UI Animations
 - [Web Tools Weekly](http://webtoolsweekly.com/)- Web Tools Weekly is a front-end development and web design newsletter with a focus on tools.
@@ -137,6 +151,7 @@ ___
 - [Waypoints](http://imakewebthings.com/waypoints/) - Trigger a function when you scroll to an element
 
 ### PHP
+
 - [Composer](https://getcomposer.org) - PHP Package Manager
 - [PHPUnit](http://phpunit.de) - Defacto unit test suite for PHP
 - [Chronos](https://github.com/cakephp/chronos) - Maintained fork of Carbon
@@ -144,6 +159,7 @@ ___
 - [OAuth 2.0 Server](https://oauth2.thephpleague.com/) - Makes implementing a standards compliant OAuth 2.0 server trivial
 
 ## Podcasts
+
 - [Code Newbie](http://www.codenewbie.org/) - The most supportive community of programmers 
 and people learning to code.
 - [The Laravel Podcast](http://www.laravelpodcast.com/) - The Laravel Podcast brings you Laravel and PHP development news and discussion. The podcast is hosted by Matt Stauffer and regular guests include Taylor Otwell (the creator of Laravel) and Jeffrey Way (the creator of Laracasts).
@@ -159,7 +175,8 @@ and people learning to code.
 
 ---
 
-## Popular Tools 
+## Popular Tools
+
 - [regex101](https://regex101.com) - Online regex tester and debugger: PHP, PCRE, Python, Golang and JavaScript.
 - [CSS Inliner](http://templates.mailchimp.com/resources/inline-css/) - Automatically inline your email’s CSS
 - [NTH-Test](http://nth-test.com/) - nth-child and nth-of-type Tester
@@ -183,7 +200,9 @@ and people learning to code.
 ---
 
 ## Social
+
 ### YouTube Channels
+
 - [Coding Blocks](https://www.youtube.com/user/codingblocks) - Tutorials, how to's, tips and tricks.
 - [Computerphile](https://www.youtube.com/user/Computerphile/videos) - Must watch for every CS student.
 - [ComputerHistory](https://www.youtube.com/user/ComputerHistory/videos) - For those who like to know how we reached where we are.
@@ -192,7 +211,8 @@ and people learning to code.
 - [O'Reilly](https://www.youtube.com/user/OreillyMedia/videos) - Interviews and talks of world's best technical writers.
 - [DevTips](https://www.youtube.com/user/DevTipsForDesigners/videos) - Web dev tutorials
 
-### Twitter 
+### Twitter
+
 - [@thepracticaldev](https://twitter.com/ThePracticalDev) - Blog account with a weekly Twitter chat
 - [@iamdevloper](https://twitter.com/iamdevloper) - Humor account about life as a developer
 - [@chromedevelopers](https://twitter.com/ChromiumDev) - Account for Chrome Developers
@@ -200,6 +220,7 @@ and people learning to code.
 ___
 
 ### Reddit
+
 - [Reddit Web_design](https://www.reddit.com/r/web_design/) - Upvoting reddit mechanics ensure that anything which rises to the top is essential reading for web designers. It’s very popular, one of the largest subreddits.
 - [/r/design](https://www.reddit.com/r/design) - Design subreddit
 - [/r/usability](https://www.reddit.com/r/usability) - User experience, Interface design, or Human Factors subreddit

--- a/README.md
+++ b/README.md
@@ -19,43 +19,43 @@
 ___
 
 ## Tutorials
-- [Wes Bos Javascript 30](https://javascript30.com/)- Free vanilla JavaScript course covering the basics of JavaScript.
-- [Egghead.io](https://egghead.io/)- A Mix of free and paid courses for Front End Frameworks and JavaScript.
-- [Linkedin Learning](www.linkedin.com/learning)- A library of courses on a full range of a variety of topics. This was Lynda before.
-- [The Bash Guide](http://guide.bash.academy)- Very good guide for learning the Bash Shell.
-- [A Hacker's Guide to Git](https://wildlyinaccurate.com/a-hackers-guide-to-git/)- For those wanting to learn git with a solid foundation.
-- [CSS Grid Garden](http://cssgridgarden.com/)- Easy game to learn CSS Grid.
-- [Object-Oriented JavaScript](https://www.udacity.com/course/ud015)- Learn how to utilize the various object-oriented programming features within JavaScript, and more importantly, how to write reusable and maintainable libraries.
-- [JavaScript Design Patterns](https://www.udacity.com/course/ud989)- Free course to learn the importance of separating concerns when writing JavaScript, gaining hands-on experience along the way
-- [JavaScript Advanced Tutorial by HTML Dog](http://htmldog.com/guides/javascript/advanced/)-Advanced JS tutorial
-- [Intro to Computer Science in JavaScript](https://codehs.com/info/curriculum/introjs)- An online course to help bring CS into Highschools. 
+- [Wes Bos Javascript 30](https://javascript30.com/) - Free vanilla JavaScript course covering the basics of JavaScript.
+- [Egghead.io](https://egghead.io/) - A Mix of free and paid courses for Front End Frameworks and JavaScript.
+- [Linkedin Learning](www.linkedin.com/learning) - A library of courses on a full range of a variety of topics. This was Lynda before.
+- [The Bash Guide](http://guide.bash.academy) - Very good guide for learning the Bash Shell.
+- [A Hacker's Guide to Git](https://wildlyinaccurate.com/a-hackers-guide-to-git/) - For those wanting to learn git with a solid foundation.
+- [CSS Grid Garden](http://cssgridgarden.com/) - Easy game to learn CSS Grid.
+- [Object-Oriented JavaScript](https://www.udacity.com/course/ud015) - Learn how to utilize the various object-oriented programming features within JavaScript, and more importantly, how to write reusable and maintainable libraries.
+- [JavaScript Design Patterns](https://www.udacity.com/course/ud989) - Free course to learn the importance of separating concerns when writing JavaScript, gaining hands-on experience along the way
+- [JavaScript Advanced Tutorial by HTML Dog](http://htmldog.com/guides/javascript/advanced/) - Advanced JS tutorial
+- [Intro to Computer Science in JavaScript](https://codehs.com/info/curriculum/introjs) - An online course to help bring CS into Highschools. 
 
 ---
 
 ## Articles
-- [Design Patterns](https://sourcemaking.com/design_patterns)- Design Patterns explained in detail with examples.
-- [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well/)- How to become a programmer, or the art of Googling well.
-- [Software design pattern](https://en.wikipedia.org/wiki/Software_design_pattern)- The entire collection of Design Patterns.
+- [Design Patterns](https://sourcemaking.com/design_patterns) - Design Patterns explained in detail with examples.
+- [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well/) - How to become a programmer, or the art of Googling well.
+- [Software design pattern](https://en.wikipedia.org/wiki/Software_design_pattern) - The entire collection of Design Patterns.
 - [40 Keys Computer Science Concepts Explained In Layman’s Terms](http://carlcheo.com/compsci)
 - [A Gentle Introduction To Graph Theory](https://dev.to/vaidehijoshi/a-gentle-introduction-to-graph-theory)
-- [A Software Developer’s Reading List](https://stevewedig.com/2014/02/03/software-developers-reading-list/)- Some good books and links in there.
-- [Data structure and Algorithms](https://techiedelight.quora.com/500-Data-Structures-and-Algorithms-practice-problems-and-their-solutions)- List of some algoritms and datastructure with their solutions.
+- [A Software Developer’s Reading List](https://stevewedig.com/2014/02/03/software-developers-reading-list/) - Some good books and links in there.
+- [Data structure and Algorithms](https://techiedelight.quora.com/500-Data-Structures-and-Algorithms-practice-problems-and-their-solutions) - List of some algorithms and data structure with their solutions.
 - [Data Structure Map](https://fkcd.ca/b7d.svg)
 - [Dive into the byte code](https://www.wikiwand.com/en/Java_bytecode)
 - [Expectations of a Junior Developer](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer/)
 - [List of algorithms](https://www.wikiwand.com/en/List_of_algorithms)
 - [The Key To Accelerating Your Coding Skills](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant/)
 - [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967/)
-- [Why fast pages are important](https://fly.io/articles/why-fast-pages-are-important/)- Why App Speed Matters, Revenue 
-- [Programmer Competency Matrix](http://sijinjoseph.com/programmer-competency-matrix/)- Article for knowing what our level as a programmer is.
+- [Why fast pages are important](https://fly.io/articles/why-fast-pages-are-important/) - Why App Speed Matters, Revenue 
+- [Programmer Competency Matrix](http://sijinjoseph.com/programmer-competency-matrix/) - Article for knowing what our level as a programmer is.
 - [16 JavaScript Concepts Every Programmer Should Know](http://javascriptissexy.com/16-javascript-concepts-you-must-know-well/)
 
 ---
 
 ## Blogs
-- [The Practical Dev](https://dev.to/)- A collection of posts on life as a programmer, technical posts etc. 
-- [A List Apart: For People Who Make Websites](http://alistapart.com/)-One of the most popular and influential web design blogs.
-- [Web Designer Depot — Web Design Blog](http://www.webdesignerdepot.com/)- WebDesigner Depot provides great posts about web design. Definitely one of the biggest blogs about web design and an excellent resource to keep handy.
+- [The Practical Dev](https://dev.to/) - A collection of posts on life as a programmer, technical posts etc. 
+- [A List Apart: For People Who Make Websites](http://alistapart.com/) - One of the most popular and influential web design blogs.
+- [Web Designer Depot — Web Design Blog](http://www.webdesignerdepot.com/) - WebDesigner Depot provides great posts about web design. Definitely one of the biggest blogs about web design and an excellent resource to keep handy.
 
 ---
 
@@ -68,16 +68,16 @@ ___
 - Computer Science Distilled - Wladston Ferriera 
 
 ### General
-- Refactoring- Martin Fowler
-- Zero Bugs and Program Faster- Kate Thompson
-- The Mythical Man Month- Fred Brooks
-- [Pragmatic Programmer]- Andy Hunt and Dave Thomas
-- Extreme Programming Explained- Kent Beck
-- Introduction to Algorithms- Thomas H Cormen
-- Clean Code: A Handbook of Agile Software Craftsmanship- Robert C Martin
-- Cracking the Coding Interview- Gayle Laakmann
-- 2018 Front-End Developer Handbook(https://frontendmasters.com/books/front-end-handbook/2018/)- Cody Lindley
-- DevOps for Dummies- Emily Freeman
+- Refactoring - Martin Fowler
+- Zero Bugs and Program Faster - Kate Thompson
+- The Mythical Man Month - Fred Brooks
+- [Pragmatic Programmer] - Andy Hunt and Dave Thomas
+- Extreme Programming Explained - Kent Beck
+- Introduction to Algorithms - Thomas H Cormen
+- Clean Code: A Handbook of Agile Software Craftsmanship - Robert C Martin
+- Cracking the Coding Interview - Gayle Laakmann
+- 2018 Front-End Developer Handbook(https://frontendmasters.com/books/front-end-handbook/2018/) - Cody Lindley
+- DevOps for Dummies - Emily Freeman
 
 ### JavaScript
 - JavaScript: The Good Parts - Douglas Crockford
@@ -90,18 +90,18 @@ ___
 
 ### Object Oriented Design
 - Design Patterns: Elements of Reusable Object-Oriented Software- aka the "Gang Of Four" book, or GOF
-- Practical Object-Oriented Design in Ruby- Sandi Metz
-- Growing Object-Oriented Software Guided by Tests- Steve Freeman and Nat Pryce
-- Design Patterns Explained Simply- Alexander Shvets
+- Practical Object-Oriented Design in Ruby - Sandi Metz
+- Growing Object-Oriented Software Guided by Tests - Steve Freeman and Nat Pryce
+- Design Patterns Explained Simply - Alexander Shvets
 
 ### Python
-- [Digital Ocean- How to Code in Python](https://www.digitalocean.com/community/tutorials/digitalocean-ebook-how-to-code-in-python)- A free e-book created for beginners learning to code in Python.
+- [Digital Ocean- How to Code in Python](https://www.digitalocean.com/community/tutorials/digitalocean-ebook-how-to-code-in-python) - A free e-book created for beginners learning to code in Python.
 - Python All-in-One for Dummies- John Shovic
 
 ### UX/Design
-- Don't Make Me Think- Steve Krug
-- Lessons in Typography- Jim Krause
-- User Experience Revolution- Paul Boag
+- Don't Make Me Think - Steve Krug
+- Lessons in Typography - Jim Krause
+- User Experience Revolution - Paul Boag
 
 ---
 
@@ -115,15 +115,15 @@ ___
 ---
 
 ## Newsletters
-- [JavaScript Weekly](http://javascriptweekly.com/)- Weekly newsletter with only JS News
-- [The UI Animation Newsletter](http://valhead.com/newsletter/)- Newsletter covering topics on UI Animations
+- [JavaScript Weekly](http://javascriptweekly.com/) - Weekly newsletter with only JS News
+- [The UI Animation Newsletter](http://valhead.com/newsletter/) - Newsletter covering topics on UI Animations
 - [Web Tools Weekly](http://webtoolsweekly.com/)- Web Tools Weekly is a front-end development and web design newsletter with a focus on tools.
-- [PHP Weekly](http://www.phpweekly.com/)- A free once-a-week newsletter, featuring some great articles, news and blog posts. All About PHP!
-- [FrontEnd Focus](https://frontendfoc.us/)- A once–weekly roundup of the best front-end news, articles and tutorials. HTML, CSS, WebGL, Canvas, browser tech, and more.
-- [NPM](https://www.npmjs.com/npm-weekly)- Discover new notable NPM packages.
+- [PHP Weekly](http://www.phpweekly.com/) - A free once-a-week newsletter, featuring some great articles, news and blog posts. All About PHP!
+- [FrontEnd Focus](https://frontendfoc.us/) - A once–weekly roundup of the best front-end news, articles and tutorials. HTML, CSS, WebGL, Canvas, browser tech, and more.
+- [NPM](https://www.npmjs.com/npm-weekly) - Discover new notable NPM packages.
 - [Github](https://github.com/explore/subscribe) - Discover new notable repositories.
-- [Smashing Magazine](https://www.smashingmagazine.com/the-smashing-newsletter/)  A collection of tips and resources for design and front-end development.
-- [Hacker Newsletter](http://www.hackernewsletter.com) Curated by hand, delivered weekly.
+- [Smashing Magazine](https://www.smashingmagazine.com/the-smashing-newsletter/) - A collection of tips and resources for design and front-end development.
+- [Hacker Newsletter](http://www.hackernewsletter.com) - Curated by hand, delivered weekly.
 - [CSS Tricks](https://css-tricks.com/) - Hand-written newsletter of best articles and ideas from around the web sent every week.
 - [Hey Designer](https://heydesigner.com/) - Daily or Weekly curated design knowledge newsletter.
 ---
@@ -144,65 +144,65 @@ ___
 - [OAuth 2.0 Server](https://oauth2.thephpleague.com/) - Makes implementing a standards compliant OAuth 2.0 server trivial
 
 ## Podcasts
-- [Code Newbie](http://www.codenewbie.org/)-The most supportive community of programmers 
+- [Code Newbie](http://www.codenewbie.org/) - The most supportive community of programmers 
 and people learning to code.
-- [The Laravel Podcast](http://www.laravelpodcast.com/)- The Laravel Podcast brings you Laravel and PHP development news and discussion. The podcast is hosted by Matt Stauffer and regular guests include Taylor Otwell (the creator of Laravel) and Jeffrey Way (the creator of Laracasts).
-- [The PHP Roundtable](https://www.phproundtable.com/)- The PHP Roundtable is a casual gathering of developers discussing topics that PHP nerds care about. The podcast is broadcast live on YouTube from a Google Hangout On-Air.
-- [The Web Platform Podcast](https://thewebplatform.libsyn.com/)- A weekly show that dives deep into all things web from the developers building the platform today.
-- [NodeUp](http://nodeup.com/)- Fairly consistent podcast covering all things NodeJS
-- [The Craft CMS Podcast](http://craftpodcast.com/)- Weekly podcast covering all things Craft!
-- [Coding Blocks](http://www.codingblocks.net)- A podcast covering topics such as best programming practices, design patterns, coding for performance, object oriented coding, database design and implementation, tips, tricks and a whole lot of other things.
-- [Developer On Fire](http://developeronfire.com/episodes)- A podcast that shares the humanity of developers and tells stories of some of the amazing people in software, hosted by Dave Rael.
-- [Front End Happy Hour](http://frontendhappyhour.com)- A podcast featuring a panel of Software Engineers from Netflix, Evernote, Atlassian & LinkedIn talking over drinks about all things Front End development.
-- [JavaScript Jabber](https://devchat.tv/js-jabber)- A weekly discussion about JavaScript, front-end development, community, careers, and frameworks.
-- [Syntax](https://syntax.fm)- A Tasty Treats Podcast for Web Developers by Wes Bos & Scott Tolinski.
+- [The Laravel Podcast](http://www.laravelpodcast.com/) - The Laravel Podcast brings you Laravel and PHP development news and discussion. The podcast is hosted by Matt Stauffer and regular guests include Taylor Otwell (the creator of Laravel) and Jeffrey Way (the creator of Laracasts).
+- [The PHP Roundtable](https://www.phproundtable.com/) - The PHP Roundtable is a casual gathering of developers discussing topics that PHP nerds care about. The podcast is broadcast live on YouTube from a Google Hangout On-Air.
+- [The Web Platform Podcast](https://thewebplatform.libsyn.com/) - A weekly show that dives deep into all things web from the developers building the platform today.
+- [NodeUp](http://nodeup.com/) - Fairly consistent podcast covering all things NodeJS
+- [The Craft CMS Podcast](http://craftpodcast.com/) - Weekly podcast covering all things Craft!
+- [Coding Blocks](http://www.codingblocks.net) - A podcast covering topics such as best programming practices, design patterns, coding for performance, object oriented coding, database design and implementation, tips, tricks and a whole lot of other things.
+- [Developer On Fire](http://developeronfire.com/episodes) - A podcast that shares the humanity of developers and tells stories of some of the amazing people in software, hosted by Dave Rael.
+- [Front End Happy Hour](http://frontendhappyhour.com) - A podcast featuring a panel of Software Engineers from Netflix, Evernote, Atlassian & LinkedIn talking over drinks about all things Front End development.
+- [JavaScript Jabber](https://devchat.tv/js-jabber) - A weekly discussion about JavaScript, front-end development, community, careers, and frameworks.
+- [Syntax](https://syntax.fm) - A Tasty Treats Podcast for Web Developers by Wes Bos & Scott Tolinski.
 
 ---
 
 ## Popular Tools 
-- [regex101](https://regex101.com)- Online regex tester and debugger: PHP, PCRE, Python, Golang and JavaScript.
-- [CSS Inliner](http://templates.mailchimp.com/resources/inline-css/)- Automatically inline your email’s CSS
-- [NTH-Test](http://nth-test.com/)- nth-child and nth-of-type Tester
-- [What Font Is](http://www.whatfontis.com/)- Identify font from a image
-- [Stylify Me](http://stylifyme.com/)- Overview of the style guide of a site, including colors, fonts, sizing and spacing
-- [CodePen](http://codepen.io/)- A showcase of advanced techniques with editable source code
-- [Can I Use](http://caniuse.com/)- Up-to-date browser support tables for support of front-end web technologies
-- [CSS Triggers](http://csstriggers.com/)- An invaluable reference on how CSS affects performance
-- [Pesticide](http://pesticide.io/)- Chrome Extension for CSS layout debugging
-- [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/)- Analyzes website and suggest ways to make it load faster
-- [Helium](https://github.com/geuis/helium-css)- JavaScript tool to scan your site and show unused CSS
-- [TinyPNG](https://tinypng.com/)- Advanced lossy compression for PNG images
-- [JS Object Explorer](https://sdras.github.io/object-explorer/)- A tool to help you find the object method you need without digging through the docs
-- [Keycode Info](http://keycode.info/)- A good reference app built by Wes Bos to tell you what keystroke number you need
-- [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool)- A great way to test urls to see if your data and markup are being rendered correctly
-- [30 Seconds of CSS](https://atomiks.github.io/30-seconds-of-css/)- A curated collection of useful CSS snippets you can understand in 30 seconds or less.
-- [Devdocs](https://devdocs.io)- A compendium of the docs from major tech tools. Cuts down on tabs!
-- [Command Line Reference](https://ss64.com/)- A list of all of the commands you can use in Bash, macOS, CMD, Powershell, Access, VB Script, Oracle, SQL Server, ASCII, Convert MB/BG, Forum, and Passwords.
-- [Postman](https://www.getpostman.com/)- Allows developers to doucment, design, build, mock and test API's from local machine
+- [regex101](https://regex101.com) - Online regex tester and debugger: PHP, PCRE, Python, Golang and JavaScript.
+- [CSS Inliner](http://templates.mailchimp.com/resources/inline-css/) - Automatically inline your email’s CSS
+- [NTH-Test](http://nth-test.com/) - nth-child and nth-of-type Tester
+- [What Font Is](http://www.whatfontis.com/) - Identify font from a image
+- [Stylify Me](http://stylifyme.com/) - Overview of the style guide of a site, including colors, fonts, sizing and spacing
+- [CodePen](http://codepen.io/) - A showcase of advanced techniques with editable source code
+- [Can I Use](http://caniuse.com/) - Up-to-date browser support tables for support of front-end web technologies
+- [CSS Triggers](http://csstriggers.com/) - An invaluable reference on how CSS affects performance
+- [Pesticide](http://pesticide.io/) - Chrome Extension for CSS layout debugging
+- [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) - Analyzes website and suggest ways to make it load faster
+- [Helium](https://github.com/geuis/helium-css) - JavaScript tool to scan your site and show unused CSS
+- [TinyPNG](https://tinypng.com/) - Advanced lossy compression for PNG images
+- [JS Object Explorer](https://sdras.github.io/object-explorer/) - A tool to help you find the object method you need without digging through the docs
+- [Keycode Info](http://keycode.info/) - A good reference app built by Wes Bos to tell you what keystroke number you need
+- [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) - A great way to test urls to see if your data and markup are being rendered correctly
+- [30 Seconds of CSS](https://atomiks.github.io/30-seconds-of-css/) - A curated collection of useful CSS snippets you can understand in 30 seconds or less.
+- [Devdocs](https://devdocs.io) - A compendium of the docs from major tech tools. Cuts down on tabs!
+- [Command Line Reference](https://ss64.com/) - A list of all of the commands you can use in Bash, macOS, CMD, Powershell, Access, VB Script, Oracle, SQL Server, ASCII, Convert MB/BG, Forum, and Passwords.
+- [Postman](https://www.getpostman.com/) - Allows developers to doucment, design, build, mock and test API's from local machine
 
 ---
 
 ## Social
 ### YouTube Channels
-- [Coding Blocks](https://www.youtube.com/user/codingblocks)- Tutorials, how to's, tips and tricks.
-- [Computerphile](https://www.youtube.com/user/Computerphile/videos)- Must watch for every CS student.
-- [ComputerHistory](https://www.youtube.com/user/ComputerHistory/videos)- For those who like to know how we reached where we are.
+- [Coding Blocks](https://www.youtube.com/user/codingblocks) - Tutorials, how to's, tips and tricks.
+- [Computerphile](https://www.youtube.com/user/Computerphile/videos) - Must watch for every CS student.
+- [ComputerHistory](https://www.youtube.com/user/ComputerHistory/videos) - For those who like to know how we reached where we are.
 - [Google Developers](https://www.youtube.com/user/GoogleDevelopers/videos)
-- [GoogleTechTalks](https://www.youtube.com/user/GoogleTechTalks/videos)- Videos on trending topics and cool stuff happening in the tech industry.
-- [O'Reilly](https://www.youtube.com/user/OreillyMedia/videos)- Interviews and talks of world's best technical writers.
-- [DevTips](https://www.youtube.com/user/DevTipsForDesigners/videos)- Web dev tutorials
+- [GoogleTechTalks](https://www.youtube.com/user/GoogleTechTalks/videos) - Videos on trending topics and cool stuff happening in the tech industry.
+- [O'Reilly](https://www.youtube.com/user/OreillyMedia/videos) - Interviews and talks of world's best technical writers.
+- [DevTips](https://www.youtube.com/user/DevTipsForDesigners/videos) - Web dev tutorials
 
 ### Twitter 
-- [@thepracticaldev](https://twitter.com/ThePracticalDev)- Blog account with a weekly Twitter chat
-- [@iamdevloper](https://twitter.com/iamdevloper)- Humor account about life as a developer
-- [@chromedevelopers](https://twitter.com/ChromiumDev)- Account for Chrome Developers
-- [@chromedevtools](https://twitter.com/ChromeDevTools)- Twitter account for Chrome Dev Tools. They frequently release videos with debugging tips and updates on the new releases.
+- [@thepracticaldev](https://twitter.com/ThePracticalDev) - Blog account with a weekly Twitter chat
+- [@iamdevloper](https://twitter.com/iamdevloper) - Humor account about life as a developer
+- [@chromedevelopers](https://twitter.com/ChromiumDev) - Account for Chrome Developers
+- [@chromedevtools](https://twitter.com/ChromeDevTools) - Twitter account for Chrome Dev Tools. They frequently release videos with debugging tips and updates on the new releases.
 ___
 
 ### Reddit
-- [Reddit Web_design](https://www.reddit.com/r/web_design/)-Upvoting reddit mechanics ensure that anything which rises to the top is essential reading for web designers. It’s very popular, one of the largest subreddits.
-- [/r/design](https://www.reddit.com/r/design)- Design subreddit
-- [/r/usability](https://www.reddit.com/r/usability)- User experience, Interface design, or Human Factors subreddit
-- [/r/userexperience](https://www.reddit.com/r/userexperience)- User experience design subreddit
+- [Reddit Web_design](https://www.reddit.com/r/web_design/) - Upvoting reddit mechanics ensure that anything which rises to the top is essential reading for web designers. It’s very popular, one of the largest subreddits.
+- [/r/design](https://www.reddit.com/r/design) - Design subreddit
+- [/r/usability](https://www.reddit.com/r/usability) - User experience, Interface design, or Human Factors subreddit
+- [/r/userexperience](https://www.reddit.com/r/userexperience) - User experience design subreddit
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > To add to the repo simply grab the name, link and a short searchable description of your favorites. Try to keep it to high level products you have personally tried and would recommend to your friends and coworkers. Also tools that you wish you knew about when you were starting as a junior developer are welcomed!
 
-# Index
+## Index
 
 - [Tutorials](#tutorials)
 - [Articles](#articles)
@@ -31,7 +31,7 @@ ___
 - [Object-Oriented JavaScript](https://www.udacity.com/course/ud015) - Learn how to utilize the various object-oriented programming features within JavaScript, and more importantly, how to write reusable and maintainable libraries.
 - [JavaScript Design Patterns](https://www.udacity.com/course/ud989) - Free course to learn the importance of separating concerns when writing JavaScript, gaining hands-on experience along the way
 - [JavaScript Advanced Tutorial by HTML Dog](http://htmldog.com/guides/javascript/advanced/) - Advanced JS tutorial
-- [Intro to Computer Science in JavaScript](https://codehs.com/info/curriculum/introjs) - An online course to help bring CS into Highschools. 
+- [Intro to Computer Science in JavaScript](https://codehs.com/info/curriculum/introjs) - An online course to help bring CS into High schools.
 
 ---
 
@@ -50,7 +50,7 @@ ___
 - [List of algorithms](https://www.wikiwand.com/en/List_of_algorithms)
 - [The Key To Accelerating Your Coding Skills](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant/)
 - [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967/)
-- [Why fast pages are important](https://fly.io/articles/why-fast-pages-are-important/) - Why App Speed Matters, Revenue 
+- [Why fast pages are important](https://fly.io/articles/why-fast-pages-are-important/) - Why App Speed Matters, Revenue
 - [Programmer Competency Matrix](http://sijinjoseph.com/programmer-competency-matrix/) - Article for knowing what our level as a programmer is.
 - [16 JavaScript Concepts Every Programmer Should Know](http://javascriptissexy.com/16-javascript-concepts-you-must-know-well/)
 
@@ -58,7 +58,7 @@ ___
 
 ## Blogs
 
-- [The Practical Dev](https://dev.to/) - A collection of posts on life as a programmer, technical posts etc. 
+- [The Practical Dev](https://dev.to/) - A collection of posts on life as a programmer, technical posts etc.
 - [A List Apart: For People Who Make Websites](http://alistapart.com/) - One of the most popular and influential web design blogs.
 - [Web Designer Depot — Web Design Blog](http://www.webdesignerdepot.com/) - WebDesigner Depot provides great posts about web design. Definitely one of the biggest blogs about web design and an excellent resource to keep handy.
 
@@ -73,7 +73,7 @@ ___
 
 ### Computer Science
 
-- Computer Science Distilled - Wladston Ferriera 
+- Computer Science Distilled - Wladston Ferriera
 
 ### General
 
@@ -140,6 +140,7 @@ ___
 - [Hacker Newsletter](http://www.hackernewsletter.com) - Curated by hand, delivered weekly.
 - [CSS Tricks](https://css-tricks.com/) - Hand-written newsletter of best articles and ideas from around the web sent every week.
 - [Hey Designer](https://heydesigner.com/) - Daily or Weekly curated design knowledge newsletter.
+
 ---
 
 ## Common Plugins/Packages to solve difficult problems
@@ -160,7 +161,7 @@ ___
 
 ## Podcasts
 
-- [Code Newbie](http://www.codenewbie.org/) - The most supportive community of programmers 
+- [Code Newbie](http://www.codenewbie.org/) - The most supportive community of programmers
 and people learning to code.
 - [The Laravel Podcast](http://www.laravelpodcast.com/) - The Laravel Podcast brings you Laravel and PHP development news and discussion. The podcast is hosted by Matt Stauffer and regular guests include Taylor Otwell (the creator of Laravel) and Jeffrey Way (the creator of Laracasts).
 - [The PHP Roundtable](https://www.phproundtable.com/) - The PHP Roundtable is a casual gathering of developers discussing topics that PHP nerds care about. The podcast is broadcast live on YouTube from a Google Hangout On-Air.
@@ -217,13 +218,10 @@ and people learning to code.
 - [@iamdevloper](https://twitter.com/iamdevloper) - Humor account about life as a developer
 - [@chromedevelopers](https://twitter.com/ChromiumDev) - Account for Chrome Developers
 - [@chromedevtools](https://twitter.com/ChromeDevTools) - Twitter account for Chrome Dev Tools. They frequently release videos with debugging tips and updates on the new releases.
-___
 
 ### Reddit
 
-- [Reddit Web_design](https://www.reddit.com/r/web_design/) - Upvoting reddit mechanics ensure that anything which rises to the top is essential reading for web designers. It’s very popular, one of the largest subreddits.
+- [Reddit Web_design](https://www.reddit.com/r/web_design/) - Upvoting reddit mechanics ensure that anything which rises to the top is essential reading for web designers. It’s very popular, one of the largest subreddit
 - [/r/design](https://www.reddit.com/r/design) - Design subreddit
 - [/r/usability](https://www.reddit.com/r/usability) - User experience, Interface design, or Human Factors subreddit
 - [/r/userexperience](https://www.reddit.com/r/userexperience) - User experience design subreddit
-
----

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 ___
 
 ## Tutorials
-- [Wes Bos Javascript 30](https://javascript30.com/)- Free vanilla Javascript course covering the basics of Javascript.
-- [Egghead.io](https://egghead.io/)- A Mix of free and paid courses for Front End Frameworks and Javascript.
+- [Wes Bos Javascript 30](https://javascript30.com/)- Free vanilla JavaScript course covering the basics of JavaScript.
+- [Egghead.io](https://egghead.io/)- A Mix of free and paid courses for Front End Frameworks and JavaScript.
 - [Linkedin Learning](www.linkedin.com/learning)- A library of courses on a full range of a variety of topics. This was Lynda before.
 - [The Bash Guide](http://guide.bash.academy)- Very good guide for learning the Bash Shell.
 - [A Hacker's Guide to Git](https://wildlyinaccurate.com/a-hackers-guide-to-git/)- For those wanting to learn git with a solid foundation.
@@ -48,7 +48,7 @@ ___
 - [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967/)
 - [Why fast pages are important](https://fly.io/articles/why-fast-pages-are-important/)- Why App Speed Matters, Revenue 
 - [Programmer Competency Matrix](http://sijinjoseph.com/programmer-competency-matrix/)- Article for knowing what our level as a programmer is.
-- [16 Javascript Concepts Every Programmer Should Know](http://javascriptissexy.com/16-javascript-concepts-you-must-know-well/)
+- [16 JavaScript Concepts Every Programmer Should Know](http://javascriptissexy.com/16-javascript-concepts-you-must-know-well/)
 
 ---
 
@@ -79,14 +79,14 @@ ___
 - 2018 Front-End Developer Handbook(https://frontendmasters.com/books/front-end-handbook/2018/)- Cody Lindley
 - DevOps for Dummies- Emily Freeman
 
-### Javascript
-- JavaScript: The Good Parts- Douglas Crockford
-- Learning JavaScript Design Patterns- Addy Osmani
-- Programming JavaScript Applications- Eric Elliott
-- If Hemingway wrote Javascript- Angus Croll
-- Up and Going Javascript - Kyle Simpson
-- Principles of Object-Oriented Javascript- Nicolas Zakas
-- [Eloquent Javascript](http://eloquentjavascript.net/)-Marijn Haverbeke
+### JavaScript
+- JavaScript: The Good Parts - Douglas Crockford
+- Learning JavaScript Design Patterns - Addy Osmani
+- Programming JavaScript Applications - Eric Elliott
+- If Hemingway wrote JavaScript - Angus Croll
+- Up and Going JavaScript - Kyle Simpson
+- Principles of Object-Oriented JavaScript - Nicolas Zakas
+- [Eloquent JavaScript](http://eloquentjavascript.net/) - Marijn Haverbeke
 
 ### Object Oriented Design
 - Design Patterns: Elements of Reusable Object-Oriented Software- aka the "Gang Of Four" book, or GOF
@@ -130,7 +130,7 @@ ___
 
 ## Common Plugins/Packages to solve difficult problems
 
-### Javascript
+### JavaScript
 
 - [Moment.js](https://momentjs.com/) - Parse, validate, manipulate, and display dates and times
 - [Swiper](http://idangero.us/swiper) - Modern mobile touch slider with hardware accelerated transitions and amazing native behavior
@@ -170,7 +170,7 @@ and people learning to code.
 - [CSS Triggers](http://csstriggers.com/)- An invaluable reference on how CSS affects performance
 - [Pesticide](http://pesticide.io/)- Chrome Extension for CSS layout debugging
 - [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/)- Analyzes website and suggest ways to make it load faster
-- [Helium](https://github.com/geuis/helium-css)- Javascript tool to scan your site and show unused CSS
+- [Helium](https://github.com/geuis/helium-css)- JavaScript tool to scan your site and show unused CSS
 - [TinyPNG](https://tinypng.com/)- Advanced lossy compression for PNG images
 - [JS Object Explorer](https://sdras.github.io/object-explorer/)- A tool to help you find the object method you need without digging through the docs
 - [Keycode Info](http://keycode.info/)- A good reference app built by Wes Bos to tell you what keystroke number you need
@@ -194,8 +194,7 @@ and people learning to code.
 
 ### Twitter 
 - [@thepracticaldev](https://twitter.com/ThePracticalDev)- Blog account with a weekly Twitter chat
-- [@iamdeveloper](https://twitter.com/iamdevloper)- Humor account about life as a developer
-- [@aneventapart](https://twitter.com/aneventapart)
+- [@iamdevloper](https://twitter.com/iamdevloper)- Humor account about life as a developer
 - [@chromedevelopers](https://twitter.com/ChromiumDev)- Account for Chrome Developers
 - [@chromedevtools](https://twitter.com/ChromeDevTools)- Twitter account for Chrome Dev Tools. They frequently release videos with debugging tips and updates on the new releases.
 ___


### PR DESCRIPTION
Thank you for creating this awesome list.

I came here just to change `Javascript` to `JavaScript` with a capital `S` but ended up doing a bunch of changes.

- Renamed `Javascript` with a small `s` to `JavaScript`
- Fixed minor typos and trimmed trailing whitespaces
- Added new line after headers (Markdown linters usually recommend this) - It is also a nice aesthetic change
- Added a space before and after the `-`  just to make the list consistent
```diff
- [Wes Bos Javascript 30](https://javascript30.com/)- Free vanilla JavaScript course covering the basics of JavaScript.
+ [Wes Bos Javascript 30](https://javascript30.com/) - Free vanilla JavaScript course covering the basics of JavaScript.
```
- Removed `https://twitter.com/aneventapart` from the list as it is a [web design conference for UX & front-end experts](https://aneventapart.com/). I don't think adding conference twitter handles to the list is of much help for junior developers

Let me know if this looks good to your or if I need to revert back any of the changes.
